### PR TITLE
src: Switched to using STL containers  for memory management

### DIFF
--- a/src/lazy_sockets.h
+++ b/src/lazy_sockets.h
@@ -266,10 +266,10 @@ public:
 
 }; // class LSocket {
 
+}  // namespace lsc
+
 
 // include utility interfaces
 #include "receivers.h"
-
-}  // namespace lsc
 
 #endif // #ifndef __LAZY_SOCKETS


### PR DESCRIPTION
Switched to using STL containers for memory management in
receivers.

Fixes [issue_tracker#14](https://github.com/HoboVR-Labs/issue_tracker/issues/14)

Signed-off-by: Oleg Vorobiov <oleg.vorobiov@hobovrlabs.org>