### PR TITLE
src: Fixed random WSA cleanup (Windows only)

### DIFF
--- a/src/lazy_sockets.h
+++ b/src/lazy_sockets.h
@@ -225,7 +225,7 @@ public:
 	// close currently open connection, returns error code
 	// returns 0 on success or -1 on error
 	inline int Close()  {
-		_status = EStat_closed;
+		_status |= EStat_closed;
 		return close(_soc_handle);
 	}
 


### PR DESCRIPTION
Fixed a bug where WSA would get called prematurely, caused
by active socket count not incremented by accept calls.
Symptoms of this bug would for example be the server
stsarting up fine, but right after the binder socket goes
out of scope all accepted sockets fail with
WSANOTINITIALIZED.

Signed-off-by: Oleg Vorobiov <oleg.vorobiov@hobovrlabs.org>